### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/rswag-ui/lib/rswag/ui/middleware.rb
+++ b/rswag-ui/lib/rswag/ui/middleware.rb
@@ -37,7 +37,7 @@ module Rswag
       end
 
       def template_filename
-        @config.template_locations.find { |filename| File.exists?(filename) }
+        @config.template_locations.find { |filename| File.exist?(filename) }
       end
     end
   end


### PR DESCRIPTION
File.exists? method has been removed in Ruby 3 and we are seeing errors in Connect-api when someone calls rswag-ui endpoint, since it uses Ruby3+.
Updating to use File.exist? instead